### PR TITLE
Add method to document schemas.

### DIFF
--- a/json_schemas/channelback_payload.json
+++ b/json_schemas/channelback_payload.json
@@ -1,4 +1,5 @@
 {
+  "description": "Expected payload in response to a channelback request.",
   "type": "object",
   "required": ["external_id"],
   "properties": {

--- a/ruby/lib/any_channel_json_schemas.rb
+++ b/ruby/lib/any_channel_json_schemas.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 # The AnyChannelJSONSchemas module exposes a single method for each json schema file in the json_schemas directory.
 # Each method returns the full file path as a string.
 #
@@ -5,7 +7,10 @@
 #   AnyChannelJSONSchemas.manifest
 #   => "<full_file_path_to_gem>/manifest.json"
 module AnyChannelJSONSchemas
-  Dir["#{File.dirname(File.expand_path(__FILE__))}/../json_schemas/*.json"].each do |file_path|
+  PATH = File.dirname(File.expand_path(__FILE__)) + "/../json_schemas"
+  SCHEMA_FILES = Dir[PATH + "/*"]
+
+  SCHEMA_FILES.each do |file_path|
     basename  = File.basename(file_path, '.json')
 
     define_method(basename) do
@@ -13,4 +18,39 @@ module AnyChannelJSONSchemas
     end
     module_function basename.to_sym
   end
+
+  def documentation(schema = 'all')
+    output = ''
+
+    if schema == 'all'
+      SCHEMA_FILES.each do |file_path|
+        output << format_output(file_path)
+      end
+    elsif SCHEMA_FILES.map { |f| File.basename(f, '.json') }.include?(schema.to_s)
+      file_path = PATH + '/' + schema + '.json'
+
+      output << format_output(file_path)
+    else
+      raise "No schema file with the name: #{schema}"
+    end
+
+    output.chomp
+  end
+  module_function :documentation
+
+  def format_output(file_path)
+    output = ''
+
+    json = JSON.parse(File.read(file_path))
+    description = json.delete('description')
+    json_output = JSON.pretty_generate(json).split("\n").map { |p| "\s\s#{p}" }.join("\n")
+
+    output << "method_name: #{File.basename(file_path, '.json')}\n"
+    output << "description: #{description}\n"
+    output << "schema:\n"
+    output << "#{json_output}\n\n"
+
+    output
+  end
+  module_function :format_output
 end


### PR DESCRIPTION
This code is kind of messy but thought I'd put up a quick PR to get feedback.

This adds a `documentation` method to describe the methods. Each schema would need to define a `description` attribute at the root level. This adds one for `channelback_payload` as an example. The method takes in an optional method name.

eg.

```
AnyChannelJSONSchemas.documentation('channelback_payload')

method_name: channelback_payload
description: Expected payload in response to a channelback request.
schema:
  {
    "type": "object",
    "required": [
      "external_id"
    ],
    "properties": {
      "external_id": {
        "type": "string"
      },
      "allow_channelback": {
        "type": "boolean"
      },
      "metadata_needs_update": {
        "type": "boolean"
      },
      "metadata": {
        "type": "string"
      }
    }
  }
```

With no arguments the method outputs all of the schemas.

Obviously this isn't critical but it is easy to do and at the very least could be used to automate the `README` or something. Thoughts? @zendesk/ocean 