### PR TITLE
Update manifest.json schema

### DIFF
--- a/json_schemas/manifest.json
+++ b/json_schemas/manifest.json
@@ -21,10 +21,10 @@
             "pull_url": {"type": "string", "format": "https-url"},
             "channelback_url": {"type": "string", "format": "https-url"},
             "clickthrough_url": {"type": "string", "format": "https-url"},
-            "healthcheck_url": {"type": "string"},
-            "about_url": {"type": "string"},
-            "dashboard_url": {"type": "string"},
-            "event_callback_url": {"type": "string"}
+            "healthcheck_url": {"type": "string", "format": "https-url"},
+            "about_url": {"type": "string", "format": "https-url"},
+            "dashboard_url": {"type": "string", "format": "https-url"},
+            "event_callback_url": {"type": "string", "format": "https-url"}
           }
         }
       }

--- a/ruby/any_channel_json_schemas.gemspec
+++ b/ruby/any_channel_json_schemas.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
   gem.name          = 'any_channel_json_schemas'
   gem.require_paths = ['lib']
-  gem.version       = '0.0.2'
+  gem.version       = '0.0.3'
   gem.license       = 'Apache-2.0'
 end


### PR DESCRIPTION
@zendesk/ocean 

Update `manifest.json` schema. The current schema does not validate relative urls. The reason this schema currently works for us is because we validate against the schema after calling `extend_manifest_urls`: https://github.com/zendesk/zendesk_channels/blob/ea7ac5d53756fa6ea3bafdba653ee92be697d869/app/models/channels/any_channel/registered_integration_service.rb#L137