### PR TITLE
Support attachments in external_resource schema

### DIFF
--- a/json_schemas/external_resource.json
+++ b/json_schemas/external_resource.json
@@ -11,7 +11,8 @@
     "author": {"$ref": "#/definitions/author"},
     "display_info": {"type": "array", "items": {"$ref": "#/definitions/display_info"} },
     "allow_channelback": {"type":"boolean"},
-    "fields": {"type": "array", "items": {"$ref": "#/definitions/field_value"} }
+    "fields": {"type": "array", "items": {"$ref": "#/definitions/field_value"} },
+    "attachments": {"type": "array", "items": {"$ref": "#/definitions/attachment_value"}, "maxItems": 10 }
   },
   "definitions": {
     "external_resource": {
@@ -41,6 +42,10 @@
         "id": {"type": ["integer", "string"]},
         "value": {"type": "any"}
       }
+    },
+    "attachment_value": {
+      "type": "string",
+      "format": "https-url"
     }
   }
 }

--- a/ruby/any_channel_json_schemas.gemspec
+++ b/ruby/any_channel_json_schemas.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
   gem.name          = 'any_channel_json_schemas'
   gem.require_paths = ['lib']
-  gem.version       = '0.0.2'
+  gem.version       = '0.0.3'
   gem.license       = 'Apache-2.0'
 end


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description
Add `attachments` field to external resource schema.