### PR TITLE
Update manifest.json schema

### DIFF
--- a/json_schemas/manifest.json
+++ b/json_schemas/manifest.json
@@ -24,7 +24,7 @@
             "healthcheck_url": {"type": "string"},
             "about_url": {"type": "string"},
             "dashboard_url": {"type": "string"},
-            "event_callback_url": {"type": "string"}
+            "event_callback_url": {"type": "string", "format": "https-url"}
           }
         }
       }

--- a/ruby/any_channel_json_schemas.gemspec
+++ b/ruby/any_channel_json_schemas.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
   gem.name          = 'any_channel_json_schemas'
   gem.require_paths = ['lib']
-  gem.version       = '0.0.3'
+  gem.version       = '0.0.4'
   gem.license       = 'Apache-2.0'
 end


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description
Update `event_callback_url` format in manifest schema to require https.