### PR TITLE
CT-2250: Normalize duplicate external ID schema

### DIFF
--- a/json_schemas/event_callback_pull_request.json
+++ b/json_schemas/event_callback_pull_request.json
@@ -12,12 +12,12 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["external_id", "request_id", "ticket_nice_id", "comment_id"],
+            "required": ["external_id", "request_id", "ticket_id", "comment_id"],
             "properties": {
               "external_id": {"type": "string"},
               "request_id": {"type": "string"},
-              "ticket_nice_id": {"type": "string"},
-              "comment_id": {"type": "string"}
+              "ticket_id": {"type": "number"},
+              "comment_id": {"type": "number"}
             }
           }
         }

--- a/ruby/any_channel_json_schemas.gemspec
+++ b/ruby/any_channel_json_schemas.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
   gem.name          = 'any_channel_json_schemas'
   gem.require_paths = ['lib']
-  gem.version       = '0.1.1'
+  gem.version       = '0.2.0'
   gem.license       = 'Apache-2.0'
 end


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description

IDs should be numbers, not strings, and we standardized on the term `ticket_id` instead of `ticket_nice_id`

### References
- JIRA: https://zendesk.atlassian.net/browse/CT-2250

### Risks
- Low: Could break duplicate ID callbacks, but I think they're already broken
