### PR TITLE
CT-2258: Releasing the rename of attachments to file_urls

### DIFF
--- a/ruby/any_channel_json_schemas.gemspec
+++ b/ruby/any_channel_json_schemas.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
   gem.name          = 'any_channel_json_schemas'
   gem.require_paths = ['lib']
-  gem.version       = '0.2.0'
+  gem.version       = '0.3.0'
   gem.license       = 'Apache-2.0'
 end


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description

Releasing version 0.3.0 of the Gem, which includes the rename of `attachments` to `file_urls`.

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2258

### Risks
* Low: just a bump; Gem is already released to rubygems.org

