### PR TITLE
CT-2253: TicketID/CommentID optional on duplicate external_id

### DIFF
--- a/json_schemas/event_callback_pull_request.json
+++ b/json_schemas/event_callback_pull_request.json
@@ -12,7 +12,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["external_id", "request_id", "ticket_id", "comment_id"],
+            "required": ["external_id", "request_id"],
             "properties": {
               "external_id": {"type": "string"},
               "request_id": {"type": "string"},


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description

ticket_id and comment_id should be optional in duplicate_external_ids

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2253

### Risks
* low: making items optional shouldn't break anything, but it might allow us to return incomplete information

