### PR TITLE
Remove maxItems from file_urls validation

### DIFF
--- a/json_schemas/external_resource.json
+++ b/json_schemas/external_resource.json
@@ -12,7 +12,7 @@
     "display_info": {"type": "array", "items": {"$ref": "#/definitions/display_info"} },
     "allow_channelback": {"type":"boolean"},
     "fields": {"type": "array", "items": {"$ref": "#/definitions/field_value"} },
-    "file_urls": {"type": "array", "items": {"$ref": "#/definitions/file_url"}, "maxItems": 10 }
+    "file_urls": {"type": "array", "items": {"$ref": "#/definitions/file_url"} }
   },
   "definitions": {
     "external_resource": {

--- a/ruby/any_channel_json_schemas.gemspec
+++ b/ruby/any_channel_json_schemas.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
   gem.name          = 'any_channel_json_schemas'
   gem.require_paths = ['lib']
-  gem.version       = '0.4.0'
+  gem.version       = '0.5.0'
   gem.license       = 'Apache-2.0'
 end


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description
* We have code in Channels to handle when there are too many file urls for an external resource so we should remove the limit from schema validation.

### Risks
* low: this change will make json validation for attachments more lax