### PR TITLE
CT-2303: Disallow zero length strings

### DIFF
--- a/json_schemas/external_resource.json
+++ b/json_schemas/external_resource.json
@@ -2,11 +2,11 @@
   "type": "object",
   "required": ["external_id", "message", "author", "created_at"],
   "properties": {
-    "external_id": {"type": "string"},
+    "external_id": {"type": "string", "minLength": 1},
     "message": {"type": "string"},
     "html_message": {"type": "string"},
-    "parent_id": {"type": "string"},
-    "thread_id": {"type": "string"},
+    "parent_id": {"type": "string", "minLength": 1},
+    "thread_id": {"type": "string", "minLength": 1},
     "created_at": {"type": "string", "format": "date-time"},
     "author": {"$ref": "#/definitions/author"},
     "display_info": {"type": "array", "items": {"$ref": "#/definitions/display_info"} },
@@ -21,17 +21,17 @@
       "type": "object",
       "required": ["external_id"],
       "properties": {
-        "external_id": {"type": "string"},
-        "name": {"type": "string"},
-        "image_url": {"type": "string"},
-        "locale": {"type": "string"}
+        "external_id": {"type": "string", "minLength": 1},
+        "name": {"type": "string", "minLength": 1},
+        "image_url": {"type": "string", "minLength": 1},
+        "locale": {"type": "string", "minLength": 1}
       }
     },
     "display_info": {
       "type": "object",
       "required": ["type", "data"],
       "properties": {
-        "type": {"type": "string"},
+        "type": {"type": "string", "minLength": 1},
         "data": {"type": "object"}
       }
     },
@@ -39,7 +39,7 @@
       "type": "object",
       "required": ["id", "value"],
       "properties": {
-        "id": {"type": ["integer", "string"]},
+        "id": {"type": ["integer", "string"], "minLength": 1},
         "value": {"type": "any"}
       }
     },

--- a/json_schemas/manifest.json
+++ b/json_schemas/manifest.json
@@ -5,11 +5,11 @@
       "type": "object",
       "required": ["name", "id", "urls"],
       "properties": {
-        "name": {"type": "string"},
-        "id": {"type": "string"},
-        "version": {"type": "string"},
-        "author": {"type": "string"},
-        "push_client_id": {"type": "string"},
+        "name": {"type": "string", "minLength": 1},
+        "id": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "author": {"type": "string", "minLength": 1},
+        "push_client_id": {"type": "string", "minLength": 1},
         "urls": { "$ref": "#/definitions/manifest/definitions/urls"}
       },
       "definitions": {

--- a/json_schemas/push_parameters.json
+++ b/json_schemas/push_parameters.json
@@ -2,8 +2,8 @@
   "type": "object",
   "required": ["instance_push_id", "external_resources"],
   "properties": {
-    "instance_push_id": {"type": "string"},
-    "request_id": {"type": "string"},
+    "instance_push_id": {"type": "string", "minLength": 1},
+    "request_id": {"type": "string", "minLength": 1},
     "external_resources": {"type": "array", "items": { "$ref": "external_resource.json"} }
   }
 }


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean @JaredShay 

### Description

Disallow zero length strings when they're nonsensical.  The major case is author name, since Zendesk doesn't support zero length names, but I tried to cover other obvious cases as well.

I didn't write any unit tests; it looks like this repo doesn't contain tests?  This should be tested before we actually use it.

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2303

### Risks
* Medium: Could break AnyChannel, could break cases where zero length strings are actually desirable and allowed.
