### PR TITLE
CT-2335: Messages may not be zero length

### DIFF
--- a/json_schemas/external_resource.json
+++ b/json_schemas/external_resource.json
@@ -3,8 +3,8 @@
   "required": ["external_id", "message", "author", "created_at"],
   "properties": {
     "external_id": {"type": "string", "minLength": 1},
-    "message": {"type": "string"},
-    "html_message": {"type": "string"},
+    "message": {"type": "string", "minLength": 1},
+    "html_message": {"type": "string", "minLength": 1},
     "parent_id": {"type": "string", "minLength": 1},
     "thread_id": {"type": "string", "minLength": 1},
     "created_at": {"type": "string", "format": "date-time"},


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description

AnyChannel messages may not be zero-length since Zendesk Comments may not be zero-length.

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2335

### Risks
* Low: could cause AnyChannel imports to fail for all external resources (if this causes all resources to fail to validate)