### PR TITLE
CT-2338: Enforce schema on external_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ The schemas and libraries in this repo and intended to be used in code and we wa
 
 To make sure this is always the case we're letting the community in on our super secret internal code name. Don't tell anyone ;)
 
+### Custom formats
+
+These schemas use some custom formats
+
+* https-url
+* external-id
+
+#### https-url
+
+This custom format enforces that the URL uses the HTTPS scheme.  For example, 'https://www.test.com/document' passes, but 'http://www.test.com/document' does not.
+
+#### external-id
+
+This custom format enforces that the string does not include leading or trailing whitespace.  For example '123' passes, but '123 ' does not.
+
 ### License
 
 [Apache License](./LICENSE)

--- a/json_schemas/channelback_payload.json
+++ b/json_schemas/channelback_payload.json
@@ -2,7 +2,7 @@
   "type": "object",
   "required": ["external_id"],
   "properties": {
-    "external_id": {"type": "string"},
+    "external_id": {"type": "string", "format": "external-id"},
     "allow_channelback": {"type": "boolean"},
     "metadata_needs_update": {"type": "boolean"},
     "metadata": {"type": "string"}

--- a/json_schemas/external_resource.json
+++ b/json_schemas/external_resource.json
@@ -2,11 +2,11 @@
   "type": "object",
   "required": ["external_id", "message", "author", "created_at"],
   "properties": {
-    "external_id": {"type": "string", "minLength": 1},
+    "external_id": {"type": "string", "minLength": 1, "format": "external-id"},
     "message": {"type": "string", "minLength": 1},
     "html_message": {"type": "string", "minLength": 1},
-    "parent_id": {"type": "string", "minLength": 1},
-    "thread_id": {"type": "string", "minLength": 1},
+    "parent_id": {"type": "string", "minLength": 1, "format": "external-id"},
+    "thread_id": {"type": "string", "minLength": 1, "format": "external-id"},
     "created_at": {"type": "string", "format": "date-time"},
     "author": {"$ref": "#/definitions/author"},
     "display_info": {"type": "array", "items": {"$ref": "#/definitions/display_info"} },
@@ -21,7 +21,7 @@
       "type": "object",
       "required": ["external_id"],
       "properties": {
-        "external_id": {"type": "string", "minLength": 1},
+        "external_id": {"type": "string", "minLength": 1, "format": "external-id"},
         "name": {"type": "string", "minLength": 1},
         "image_url": {"type": "string", "minLength": 1},
         "locale": {"type": "string", "minLength": 1}


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean @JaredShay 

### Description

Enforce a custom schema on external_ids.  This will eventually enforce that `external_id == external_id.strip` to assure there's no leading or trailing whitespace.

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2338

### Risks
* Medium: Existing integrations which rely on leading or trailing whitespace may fail
