### PR TITLE
Revert "Remove maxItems from file_urls validation"

### DIFF
--- a/json_schemas/external_resource.json
+++ b/json_schemas/external_resource.json
@@ -12,7 +12,7 @@
     "display_info": {"type": "array", "items": {"$ref": "#/definitions/display_info"} },
     "allow_channelback": {"type":"boolean"},
     "fields": {"type": "array", "items": {"$ref": "#/definitions/field_value"} },
-    "file_urls": {"type": "array", "items": {"$ref": "#/definitions/file_url"} }
+    "file_urls": {"type": "array", "items": {"$ref": "#/definitions/file_url"}, "maxItems": 10 }
   },
   "definitions": {
     "external_resource": {

--- a/ruby/any_channel_json_schemas.gemspec
+++ b/ruby/any_channel_json_schemas.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
   gem.name          = 'any_channel_json_schemas'
   gem.require_paths = ['lib']
-  gem.version       = '0.6.0'
+  gem.version       = '0.7.0'
   gem.license       = 'Apache-2.0'
 end


### PR DESCRIPTION
This reverts commit 265d8c70176a1822eb1ca79691c6d2cc9510fe72.

:ocean:

/cc @zendesk/ocean @austin-wang 

### Description

Reverting https://github.com/zendesk/any_channel_json_schemas/pull/15 in an effort to get tests at https://github.com/zendesk/zendesk_channels/blob/master/test/controllers/zendesk/channels/api/v2/any_channel_push_controller_test.rb#L164 to pass

### References
* JIRA: n/a

### Risks
* Low: could cause multiple AnyChannel attachments to fail
