### PR TITLE
CT-2418: Max array lengths

### DIFF
--- a/json_schemas/external_resource.json
+++ b/json_schemas/external_resource.json
@@ -9,10 +9,10 @@
     "thread_id": {"type": "string", "minLength": 1, "maxLength": 255, "format": "external-id"},
     "created_at": {"type": "string", "maxLength": 255, "format": "date-time"},
     "author": {"$ref": "#/definitions/author"},
-    "display_info": {"type": "array", "maxIems": 16, "items": {"$ref": "#/definitions/display_info"} },
+    "display_info": {"type": "array", "maxItems": 16, "items": {"$ref": "#/definitions/display_info"} },
     "allow_channelback": {"type":"boolean"},
-    "fields": {"type": "array", "maxIems": 64, "items": {"$ref": "#/definitions/field_value"} },
-    "file_urls": {"type": "array", "maxIems": 64, "items": {"$ref": "#/definitions/file_url"} }
+    "fields": {"type": "array", "maxItems": 64, "items": {"$ref": "#/definitions/field_value"} },
+    "file_urls": {"type": "array", "maxItems": 64, "items": {"$ref": "#/definitions/file_url"} }
   },
   "definitions": {
     "external_resource": {

--- a/json_schemas/external_resource.json
+++ b/json_schemas/external_resource.json
@@ -9,10 +9,10 @@
     "thread_id": {"type": "string", "minLength": 1, "maxLength": 255, "format": "external-id"},
     "created_at": {"type": "string", "maxLength": 255, "format": "date-time"},
     "author": {"$ref": "#/definitions/author"},
-    "display_info": {"type": "array", "items": {"$ref": "#/definitions/display_info"} },
+    "display_info": {"type": "array", "maxIems": 16, "items": {"$ref": "#/definitions/display_info"} },
     "allow_channelback": {"type":"boolean"},
-    "fields": {"type": "array", "items": {"$ref": "#/definitions/field_value"} },
-    "file_urls": {"type": "array", "items": {"$ref": "#/definitions/file_url"} }
+    "fields": {"type": "array", "maxIems": 64, "items": {"$ref": "#/definitions/field_value"} },
+    "file_urls": {"type": "array", "maxIems": 64, "items": {"$ref": "#/definitions/file_url"} }
   },
   "definitions": {
     "external_resource": {

--- a/json_schemas/pull_payload.json
+++ b/json_schemas/pull_payload.json
@@ -3,7 +3,7 @@
   "required": ["external_resources"],
   "properties": {
     "state": {"type": "string", "maxLength": 5000},
-    "external_resources": {"type": "array", "items": { "$ref": "external_resource.json"} },
+    "external_resources": {"type": "array", "maxIems": 256, "items": { "$ref": "external_resource.json"} },
     "metadata_needs_update": {"type": "boolean"},
     "metadata": {"type": "string", "maxLength": 5000}
   }

--- a/json_schemas/pull_payload.json
+++ b/json_schemas/pull_payload.json
@@ -3,7 +3,7 @@
   "required": ["external_resources"],
   "properties": {
     "state": {"type": "string", "maxLength": 5000},
-    "external_resources": {"type": "array", "maxIems": 256, "items": { "$ref": "external_resource.json"} },
+    "external_resources": {"type": "array", "maxItems": 256, "items": { "$ref": "external_resource.json"} },
     "metadata_needs_update": {"type": "boolean"},
     "metadata": {"type": "string", "maxLength": 5000}
   }

--- a/json_schemas/push_parameters.json
+++ b/json_schemas/push_parameters.json
@@ -4,6 +4,6 @@
   "properties": {
     "instance_push_id": {"type": "string", "minLength": 1, "maxLength": 255},
     "request_id": {"type": "string", "minLength": 1, "maxLength": 64},
-    "external_resources": {"type": "array", "maxIems": 256, "items": { "$ref": "external_resource.json"} }
+    "external_resources": {"type": "array", "maxItems": 256, "items": { "$ref": "external_resource.json"} }
   }
 }

--- a/json_schemas/push_parameters.json
+++ b/json_schemas/push_parameters.json
@@ -4,6 +4,6 @@
   "properties": {
     "instance_push_id": {"type": "string", "minLength": 1, "maxLength": 255},
     "request_id": {"type": "string", "minLength": 1, "maxLength": 64},
-    "external_resources": {"type": "array", "items": { "$ref": "external_resource.json"} }
+    "external_resources": {"type": "array", "maxIems": 256, "items": { "$ref": "external_resource.json"} }
   }
 }


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean @jstjoe 

### Description

All incoming arrays should have sane upper limits to avoid intentional or unintentional DOS-like attacks.

These limits are mostly arbitrary- we never published limits internally or externally, and most of the arrays don't have to fit into fixed data structures (unlike strings.)  I'm throwing these numbers out as a proposal/first try.

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2418

### Risks
* medium: partners might already be exceeding these limits
