### PR TITLE
CT-2662: Support channelback files

### DIFF
--- a/json_schemas/manifest.json
+++ b/json_schemas/manifest.json
@@ -10,6 +10,7 @@
         "version": {"type": "string", "minLength": 1, "maxLength": 255},
         "author": {"type": "string", "minLength": 1, "maxLength": 255},
         "push_client_id": {"type": "string", "minLength": 1, "maxLength": 128},
+        "channelback_files": {"type": "boolean"},
         "urls": { "$ref": "#/definitions/manifest/definitions/urls"}
       },
       "definitions": {


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description

Adding `channelback_files` boolean to manifest, which indicates if Integration Service supports sending files back during a Channelback (i.e. attachments on ticket comments.)

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2662

### Risks
* Low: new boolean field should be 100% backward compatible
