### PR TITLE
CT-2667: Doc API for reporting Channelback error

### DIFF
--- a/json_schemas/report_channelback_error.json
+++ b/json_schemas/report_channelback_error.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "required": ["instance_push_id", "external_id"],
+  "properties": {
+    "instance_push_id": { "type": "string", "minLength": 1, "maxLength": 255 },
+    "external_id": { "type": "string", "maxLength": 255, "format": "external-id" },
+    "request_id": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "description": { "type": "string", "maxLength": 511 }
+  }
+}


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description

Adding documentation for https://github.com/zendesk/zendesk_channels/blob/master/app/controllers/zendesk/channels/api/v2/any_channel_channelback_controller.rb#L41-L53

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2667

### Risks
* Could expose API that we'd prefer to remain private, or could be factually incorrect
