### PR TITLE
Attempting to bump version number and document change

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -18,6 +18,7 @@ pull_payload
 external_resource
 push_parameters
 channelback_payload
+report_channelback_error
 event_callback_any
 event_callback_base
 event_callback_create_integration

--- a/ruby/any_channel_json_schemas.gemspec
+++ b/ruby/any_channel_json_schemas.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
   gem.name          = 'any_channel_json_schemas'
   gem.require_paths = ['lib']
-  gem.version       = '0.6.0'
+  gem.version       = '0.7.0'
   gem.license       = 'Apache-2.0'
 end


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean @JaredShay 

### Description

Attempting to document change from https://github.com/zendesk/any_channel_json_schemas/pull/25 and bump version.  I'm not clear on exactly how we do this.

Should we have a deploy.md file in this repo?

### Risks
* Low: could cause us to release an unusable (but unused) version of any_channel_json_schemas
