### PR TITLE
Bump to version 0.8.0.

### DIFF
--- a/ruby/any_channel_json_schemas.gemspec
+++ b/ruby/any_channel_json_schemas.gemspec
@@ -9,6 +9,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- spec/*`.split("\n")
   gem.name          = 'any_channel_json_schemas'
   gem.require_paths = ['lib']
-  gem.version       = '0.7.0'
+  gem.version       = '0.8.0'
   gem.license       = 'Apache-2.0'
 end


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean @zendesk/sustaining 

### Description
Release the new gem version for consumption by `zendesk_channels`.

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2691

### Risks
* Low: Schema validation will be incorrect.
