### PR TITLE
Add request_id to channelback schema.

### DIFF
--- a/json_schemas/event_callback_channelback.json
+++ b/json_schemas/event_callback_channelback.json
@@ -3,10 +3,11 @@
   "properties": {
     "data": {
       "type": "object",
-      "required": ["integration_instance_name", "url"],
+      "required": ["integration_instance_name", "url", "request_id"],
       "properties": {
         "integration_instance_name": {"type": "string"},
-        "url": {"type": "string", "format": "https-url"}
+        "url": {"type": "string", "format": "https-url"},
+        "request_id": {"type": "string"}
       }
     }
   }


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean @zendesk/sustaining 

### Description
We're going to send the request ID with the ChannelbackEvent data so that an integration service can associate the event with a channelback request.

PR in `zendesk_channels`: https://github.com/zendesk/zendesk_channels/pull/1212

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2691

### Risks
* Low: Our channelback JSON may not match the schema.
