### PR TITLE
CT-2699: Channel Framework manifest supports create_followup_tickets

### DIFF
--- a/json_schemas/manifest.json
+++ b/json_schemas/manifest.json
@@ -11,6 +11,7 @@
         "author": {"type": "string", "minLength": 1, "maxLength": 255},
         "push_client_id": {"type": "string", "minLength": 1, "maxLength": 128},
         "channelback_files": {"type": "boolean"},
+        "create_followup_tickets": {"type": "boolean"},
         "urls": { "$ref": "#/definitions/manifest/definitions/urls"}
       },
       "definitions": {


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description

Adds a `create_followup_tickets` boolean to the manifest for RegisteredIntegrationServices.  When `true`, it means that when Zendesk processes an external resource that has a `thread_id` that corresponds to an existing closed ticket, Zendesk will create a followup ticket.  When `false`, it means that the ticket that Zendesk creates in that situation should not be a followup ticket.  Defaults to `true`.

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-2699

### Risks
* Low: new, non-mandatory boolean should not break existing code.  If severely broken, could break JSON validation or mislead third party developers.
