### PR TITLE
Ensure that all manifest URLs use SSL.

### DIFF
--- a/json_schemas/manifest.json
+++ b/json_schemas/manifest.json
@@ -23,9 +23,9 @@
             "pull_url": {"type": "string", "maxLength": 511, "format": "https-url"},
             "channelback_url": {"type": "string", "maxLength": 511, "format": "https-url"},
             "clickthrough_url": {"type": "string", "maxLength": 511, "format": "https-url"},
-            "healthcheck_url": {"type": "string", "maxLength": 511},
-            "about_url": {"type": "string", "maxLength": 511},
-            "dashboard_url": {"type": "string", "maxLength": 511},
+            "healthcheck_url": {"type": "string", "maxLength": 511, "format": "https-url"},
+            "about_url": {"type": "string", "maxLength": 511, "format": "https-url"},
+            "dashboard_url": {"type": "string", "maxLength": 511, "format": "https-url"},
             "event_callback_url": {"type": "string", "maxLength": 511, "format": "https-url"}
           }
         }


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean @zendesk/sustaining 

### Description
Currently a rogue integration service can pass javascript snippets to an agent's Support interface via the manifest. This is possible because we don't specify the format of the `dashboard_url` and `about_url`. This PR enforces that these strings must be HTTPS URLs.

As we aren't currently enforcing SSL for these URLs, this change could break some existing apps with invalid manifests. However, we do specify that `All URLs must be SSL.` in the CF docs (link below), so this change is in line with our publicly-available information.

### References
* Z1: https://support.zendesk.com/agent/tickets/3455915
* Channel Framework manifest docs: https://developer.zendesk.com/apps/docs/channels-framework/integration_manifest#urls-object

### Risks
* Medium: The install for certain integrations may break due to invalid manifest.
