### PR TITLE
Add the author object in the destroy user event

### DIFF
--- a/json_schemas/event_callback_destroy_user.json
+++ b/json_schemas/event_callback_destroy_user.json
@@ -3,8 +3,15 @@
   "properties": {
     "data": {
       "type": "object",
-      "required": ["metadata"],
+      "required": ["author", "metadata"],
       "properties": {
+        "author": {
+            "type": "object",
+            "required": ["external_id"],
+            "properties": {
+               "external_id": {"type": "string"}
+            }
+        },
         "metadata": {"type": "string"}
       }
     }


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description
After discussing with Will Mora from Smooch we decided to make the destroy user identity event more clear to understand. We switched from sending the external_id from the user in the metadata field of the event to an Object with the author field, and the metadata field was preserved to send the integration service account-specific data. In that way, integrations will have a standard structure to read from and also a way to confirm the event origin.

### Risks
* Medium: Can break the GDPR event request for Whatsapp if they don't deploy the changes on their side.
