### PR TITLE
Remove the metadata field required enforcement

### DIFF
--- a/json_schemas/event_callback_destroy_user.json
+++ b/json_schemas/event_callback_destroy_user.json
@@ -3,7 +3,7 @@
   "properties": {
     "data": {
       "type": "object",
-      "required": ["author", "metadata"],
+      "required": ["author"],
       "properties": {
         "author": {
             "type": "object",


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description
PR to complement the PR https://github.com/zendesk/zendesk_channels/pull/1367. After talking to Will Mora from Smooch we agreed that the current event payload is too simple. It helps to have an object structure in it with the author and the ISI metadata in the metadata field. The new structure looks like this:
```json
...
"data": {
  "author": {
    "external_id": "smooch123"
  },
  "metadata": "{\"webhookSecret\":\"123\",\"applicationId\":\"123\",\"integrationId\":\"123\"}"
}

```
Changes on the Smooch side are in place.

### Risks
Low: Changed the json format validation for destroy user events. Since this is only used by Smooch (and the code on their side is ready and deployed), will not affect other customers.
