### PR TITLE
Add Internal note to external resources

### DIFF
--- a/json_schemas/external_resource.json
+++ b/json_schemas/external_resource.json
@@ -3,6 +3,7 @@
   "required": ["external_id", "message", "author", "created_at"],
   "properties": {
     "external_id": {"type": "string", "minLength": 1, "maxLength": 255, "format": "external-id"},
+    "internal_note": {"type": "boolean"},
     "message": {"type": "string", "minLength": 1, "maxLength": 65535},
     "html_message": {"type": "string", "minLength": 1, "maxLength": 65535},
     "parent_id": {"type": "string", "minLength": 1, "maxLength": 255, "format": "external-id"},


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description
This PR adds the internal_note attribute to the `external_resource.json` schema validation. It is a non-required boolean field to allow Sunco CFC integration to send internal notes to Support through Channels Framework API.

### References
* JIRA: https://zendesk.atlassian.net/browse/CT-3252

### Risks
* Low: Unrequited field. In channels there is an Arturo protecting the functionality (PR link pending. Follow CT-3252)
