### PR TITLE
[PSC-455] Adds an minimum length requirement for channelback payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This custom format enforces that the URL uses the HTTPS scheme.  For example, 'h
 
 #### external-id
 
-This custom format enforces that the string does not include leading or trailing whitespace.  For example '123' passes, but '123 ' does not.
+* This custom format enforces that the string does not include leading or trailing whitespace.  For example '123' passes, but '123 ' does not.
+* The [Channel Payload V2](./json_schemas/channelback_payload_v2.json) enforces the value as non-nil. For example '123' passes, but '' does not.
 
 ### License
 

--- a/json_schemas/channelback_payload.json
+++ b/json_schemas/channelback_payload.json
@@ -2,7 +2,7 @@
   "type": "object",
   "required": ["external_id"],
   "properties": {
-    "external_id": {"type": "string", "maxLength": 255, "format": "external-id"},
+    "external_id": {"type": "string", "minLength": 1, "maxLength": 255, "format": "external-id"},
     "allow_channelback": {"type": "boolean"},
     "metadata_needs_update": {"type": "boolean"},
     "metadata": {"type": "string", "maxLength": 5000}

--- a/json_schemas/channelback_payload_v2.json
+++ b/json_schemas/channelback_payload_v2.json
@@ -2,7 +2,7 @@
   "type": "object",
   "required": ["external_id"],
   "properties": {
-    "external_id": {"type": "string", "maxLength": 255, "format": "external-id"},
+    "external_id": {"type": "string", "minLength": 1, "maxLength": 255, "format": "external-id"},
     "allow_channelback": {"type": "boolean"},
     "metadata_needs_update": {"type": "boolean"},
     "metadata": {"type": "string", "maxLength": 5000}


### PR DESCRIPTION
:ocean:

/cc @zendesk/ocean

### Description
* Introduces version 2 for Channelback payload that requires a non-nil `external_id` value from the third-party integrator to create a link between the external resource and the Zendesk Ticket. 

### References
* JIRA: https://zendesk.atlassian.net/browse/PSC-455

### Risks
* Low: Introduces a newer version for Channelback payload 
